### PR TITLE
feat(aws env): support set aws credentials in env

### DIFF
--- a/.env
+++ b/.env
@@ -9,4 +9,10 @@ HOST=127.0.0.1
 
 # CONFIGURABLE OPTIONS:
 PORT=3333
+# if you use aws config instead of credentials file, set this to 1
+AWS_SDK_LOAD_CONFIG=
+# the profile name in your credentials/config file
 AWS_PROFILE_NAME=default
+# if you want to set the credentials directly, set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=

--- a/app/Controllers/Http/SesTemplateController.js
+++ b/app/Controllers/Http/SesTemplateController.js
@@ -1,8 +1,10 @@
 'use strict'
 const Env = use('Env');
 const AWS = require('aws-sdk');
-const credentials = new AWS.SharedIniFileCredentials({profile: Env.get('AWS_PROFILE_NAME', 'default')});
-AWS.config.credentials = credentials;
+if (!(Env.get('AWS_ACCESS_KEY_ID') && Env.get('AWS_SECRET_ACCESS_KEY'))) {
+  const credentials = new AWS.SharedIniFileCredentials({profile: Env.get('AWS_PROFILE_NAME', 'default')});
+  AWS.config.credentials = credentials;
+}
 
 class SesTemplateController {
 


### PR DESCRIPTION
Hi, @MattRuddick .
Your work on this repo really helps me a lot. And I find it would be more convenient for shipment if we could set aws credentials in env directly. (such as ship on **Railway**)