### PR TITLE
Increase Body Parser Limit to Fix 413 Error on update-template Endpoint

### DIFF
--- a/config/bodyParser.js
+++ b/config/bodyParser.js
@@ -76,7 +76,8 @@ module.exports = {
   form: {
     types: [
       'application/x-www-form-urlencoded'
-    ]
+    ],
+    limit: '10mb'
   },
 
   /*


### PR DESCRIPTION
While invoking the update-template API, I encountered a `413` Payload Too Large HTTP error code. Upon investigation, it appears that the size of the form-data in the request was exceeding server limits, despite being only approximately `70kb` in size.

This issue is particularly relevant when using no-code email editors, as the emails generated can easily reach or exceed this threshold. Reviewing the `config/bodyParser.js` configuration file, I noticed that there was no explicit limit set for the body size, which led me to believe that the default limit imposed by the framework was too low for our use case.

To address this problem, I have increased the body parser limit to `10mb`. This change effectively resolves the issue and allows emails of larger sizes to be processed without encountering a `413` error.

Please consider merging this adjustment to ensure smooth operation of the update-template endpoint for all users.